### PR TITLE
Show unsaved message if options forms are changed

### DIFF
--- a/src/popup/App/Options/LotusForm/LotusForm.js
+++ b/src/popup/App/Options/LotusForm/LotusForm.js
@@ -10,12 +10,12 @@ function LotusForm(props) {
   const { handleSubmit, register, setError, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  async function onSubmit(data) {
+  function onSubmit(data) {
     const key = signer.keyRecover(data.privateKey);
     const aggregated = options.unsavedForms.payment || options.unsavedForms.price || options.unsavedForms.rendezvous;
 
     if (key.address === data.wallet || key.address === data.wallet.replace(/^t/, 'f')) {
-      await setOptions({
+      setOptions({
         ...data, unsavedForms: {
           ...options.unsavedForms,
           lotus: false,

--- a/src/popup/App/Options/LotusForm/LotusForm.js
+++ b/src/popup/App/Options/LotusForm/LotusForm.js
@@ -12,20 +12,31 @@ function LotusForm(props) {
 
   function onSubmit(data) {
     const key = signer.keyRecover(data.privateKey);
+    const aggregated = options.unsavedForms.payment || options.unsavedForms.price || options.unsavedForms.rendezvous;
 
     if (key.address === data.wallet || key.address === data.wallet.replace(/^t/, 'f')) {
-      setOptions({...data, unsaved: false});
+      setOptions({
+        ...data, unsavedForms: {
+          ...options.unsavedForms,
+          lotus: false,
+        }, unsaved: aggregated,
+      });
     } else {
       setError('privateKey', { type: 'manual', message: "Wallet and private key don't match" });
     }
   }
 
   function handleChange() {
-    setOptions({unsaved: true});
+    setOptions({
+      unsavedForms: {
+        ...options.unsavedForms,
+        lotus: true,
+      }
+    });
   }
 
   return (
-    <Card {...props}>
+    <Card {...props} className={options.unsavedForms.lotus && options.unsaved ? 'border-2-blue mb-4' : 'mb-4'}>
       <Form className="flex-col" onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <div className="flex mb-4">
           <InputField

--- a/src/popup/App/Options/LotusForm/LotusForm.js
+++ b/src/popup/App/Options/LotusForm/LotusForm.js
@@ -14,15 +14,19 @@ function LotusForm(props) {
     const key = signer.keyRecover(data.privateKey);
 
     if (key.address === data.wallet || key.address === data.wallet.replace(/^t/, 'f')) {
-      setOptions(data);
+      setOptions({...data, unsaved: false});
     } else {
       setError('privateKey', { type: 'manual', message: "Wallet and private key don't match" });
     }
   }
 
+  function handleChange() {
+    setOptions({unsaved: true});
+  }
+
   return (
     <Card {...props}>
-      <Form className="flex-col" onSubmit={handleSubmit(onSubmit)}>
+      <Form className="flex-col" onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <div className="flex mb-4">
           <InputField
             ref={register({ required: 'Required' })}

--- a/src/popup/App/Options/LotusForm/LotusForm.js
+++ b/src/popup/App/Options/LotusForm/LotusForm.js
@@ -10,12 +10,12 @@ function LotusForm(props) {
   const { handleSubmit, register, setError, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  function onSubmit(data) {
+  async function onSubmit(data) {
     const key = signer.keyRecover(data.privateKey);
     const aggregated = options.unsavedForms.payment || options.unsavedForms.price || options.unsavedForms.rendezvous;
 
     if (key.address === data.wallet || key.address === data.wallet.replace(/^t/, 'f')) {
-      setOptions({
+      await setOptions({
         ...data, unsavedForms: {
           ...options.unsavedForms,
           lotus: false,

--- a/src/popup/App/Options/Options.js
+++ b/src/popup/App/Options/Options.js
@@ -9,10 +9,10 @@ import PriceTable from './PriceTable';
 function Options({ className, ...rest }) {
   return (
     <div className={classNames(className, 'p-4')} {...rest}>
-      <RendezvousForm className="mb-4" />
-      <LotusForm className="mb-4" />
-      <PaymentForm className="mb-4" />
-      <PriceForm className="mb-4" />
+      <RendezvousForm />
+      <LotusForm />
+      <PaymentForm />
+      <PriceForm />
       <PriceTable />
     </div>
   );

--- a/src/popup/App/Options/PaymentForm/PaymentForm.js
+++ b/src/popup/App/Options/PaymentForm/PaymentForm.js
@@ -13,12 +13,17 @@ function PaymentForm(props) {
     setOptions({
       paymentInterval: parseInt(paymentInterval, 10),
       paymentIntervalIncrease: parseInt(paymentIntervalIncrease, 10),
+      unsaved: false
     });
+  }
+
+  function handleChange() {
+    setOptions({unsaved: true});
   }
 
   return (
     <Card {...props}>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <InputField
           ref={register({ required: 'Required' })}
           className="flex-1 mr-4"

--- a/src/popup/App/Options/PaymentForm/PaymentForm.js
+++ b/src/popup/App/Options/PaymentForm/PaymentForm.js
@@ -9,10 +9,10 @@ function PaymentForm(props) {
   const { handleSubmit, register, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  function onSubmit({ paymentInterval, paymentIntervalIncrease }) {
+  async function onSubmit({ paymentInterval, paymentIntervalIncrease }) {
     const aggregated = options.unsavedForms.rendezvous || options.unsavedForms.price || options.unsavedForms.lotus;
 
-    setOptions({
+    await setOptions({
       paymentInterval: parseInt(paymentInterval, 10),
       paymentIntervalIncrease: parseInt(paymentIntervalIncrease, 10),
       unsavedForms: {

--- a/src/popup/App/Options/PaymentForm/PaymentForm.js
+++ b/src/popup/App/Options/PaymentForm/PaymentForm.js
@@ -9,10 +9,10 @@ function PaymentForm(props) {
   const { handleSubmit, register, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  async function onSubmit({ paymentInterval, paymentIntervalIncrease }) {
+   function onSubmit({ paymentInterval, paymentIntervalIncrease }) {
     const aggregated = options.unsavedForms.rendezvous || options.unsavedForms.price || options.unsavedForms.lotus;
 
-    await setOptions({
+    setOptions({
       paymentInterval: parseInt(paymentInterval, 10),
       paymentIntervalIncrease: parseInt(paymentIntervalIncrease, 10),
       unsavedForms: {

--- a/src/popup/App/Options/PaymentForm/PaymentForm.js
+++ b/src/popup/App/Options/PaymentForm/PaymentForm.js
@@ -10,19 +10,30 @@ function PaymentForm(props) {
   const [options, setOptions] = useOptions();
 
   function onSubmit({ paymentInterval, paymentIntervalIncrease }) {
+    const aggregated = options.unsavedForms.rendezvous || options.unsavedForms.price || options.unsavedForms.lotus;
+
     setOptions({
       paymentInterval: parseInt(paymentInterval, 10),
       paymentIntervalIncrease: parseInt(paymentIntervalIncrease, 10),
-      unsaved: false
+      unsavedForms: {
+        ...options.unsavedForms,
+        payment: false,
+      },
+      unsaved: aggregated,
     });
   }
 
   function handleChange() {
-    setOptions({unsaved: true});
+    setOptions({
+      unsavedForms: {
+        ...options.unsavedForms,
+        payment: true,
+      }
+    });
   }
 
   return (
-    <Card {...props}>
+    <Card {...props} className={options.unsavedForms.payment && options.unsaved ? 'border-2-blue mb-4' : 'mb-4'}>
       <Form onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <InputField
           ref={register({ required: 'Required' })}

--- a/src/popup/App/Options/PriceForm/PriceForm.js
+++ b/src/popup/App/Options/PriceForm/PriceForm.js
@@ -9,10 +9,10 @@ function PriceForm(props) {
   const { handleSubmit, register, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  function onSubmit({ cid, price }) {
+  async function onSubmit({ cid, price }) {
     const aggregated = options.unsavedForms.payment || options.unsavedForms.rendezvous || options.unsavedForms.lotus;
 
-    setOptions({
+    await setOptions({
       pricesPerByte: {
         ...options.pricesPerByte,
         [cid]: parseInt(price, 10),

--- a/src/popup/App/Options/PriceForm/PriceForm.js
+++ b/src/popup/App/Options/PriceForm/PriceForm.js
@@ -10,21 +10,32 @@ function PriceForm(props) {
   const [options, setOptions] = useOptions();
 
   function onSubmit({ cid, price }) {
+    const aggregated = options.unsavedForms.payment || options.unsavedForms.rendezvous || options.unsavedForms.lotus;
+
     setOptions({
       pricesPerByte: {
         ...options.pricesPerByte,
         [cid]: parseInt(price, 10),
       },
-      unsaved: false,
+      unsavedForms: {
+        ...options.unsavedForms,
+        price: false,
+      },
+      unsaved: aggregated,
     });
   }
 
   function handleChange() {
-    setOptions({unsaved: true});
+    setOptions({
+      unsavedForms: {
+        ...options.unsavedForms,
+        price: true,
+      }
+    });
   }
 
   return (
-    <Card {...props}>
+    <Card {...props} className={options.unsavedForms.price && options.unsaved ? 'border-2-blue mb-4' : 'mb-4'}>
       <Form onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <InputField
           ref={register({ required: 'Required' })}

--- a/src/popup/App/Options/PriceForm/PriceForm.js
+++ b/src/popup/App/Options/PriceForm/PriceForm.js
@@ -9,10 +9,10 @@ function PriceForm(props) {
   const { handleSubmit, register, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  async function onSubmit({ cid, price }) {
+  function onSubmit({ cid, price }) {
     const aggregated = options.unsavedForms.payment || options.unsavedForms.rendezvous || options.unsavedForms.lotus;
 
-    await setOptions({
+    setOptions({
       pricesPerByte: {
         ...options.pricesPerByte,
         [cid]: parseInt(price, 10),

--- a/src/popup/App/Options/PriceForm/PriceForm.js
+++ b/src/popup/App/Options/PriceForm/PriceForm.js
@@ -15,12 +15,17 @@ function PriceForm(props) {
         ...options.pricesPerByte,
         [cid]: parseInt(price, 10),
       },
+      unsaved: false,
     });
+  }
+
+  function handleChange() {
+    setOptions({unsaved: true});
   }
 
   return (
     <Card {...props}>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <InputField
           ref={register({ required: 'Required' })}
           className="flex-1 mr-4"

--- a/src/popup/App/Options/RendezvousForm/RendezvousForm.js
+++ b/src/popup/App/Options/RendezvousForm/RendezvousForm.js
@@ -10,15 +10,28 @@ function RendezvousForm(props) {
   const [options, setOptions] = useOptions();
 
   function onSubmit(data) {
-    setOptions({...data, unsaved: false});
+    const aggregated = options.unsavedForms.payment || options.unsavedForms.price || options.unsavedForms.lotus;
+
+    setOptions({
+      ...data, unsavedForms: {
+        ...options.unsavedForms,
+        rendezvous: false,
+        unsaved: aggregated
+      }
+    });
   }
 
   function handleChange() {
-    setOptions({unsaved: true});
+    setOptions({
+      unsavedForms: {
+        ...options.unsavedForms,
+        rendezvous: true,
+      }
+    });
   }
 
   return (
-    <Card {...props}>
+    <Card {...props} className={options.unsavedForms.rendezvous && options.unsaved ? 'border-2-blue mb-4' : 'mb-4'}>
       <Form onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <InputField
           ref={register({ required: 'Required' })}

--- a/src/popup/App/Options/RendezvousForm/RendezvousForm.js
+++ b/src/popup/App/Options/RendezvousForm/RendezvousForm.js
@@ -10,12 +10,16 @@ function RendezvousForm(props) {
   const [options, setOptions] = useOptions();
 
   function onSubmit(data) {
-    setOptions(data);
+    setOptions({...data, unsaved: false});
+  }
+
+  function handleChange() {
+    setOptions({unsaved: true});
   }
 
   return (
     <Card {...props}>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit(onSubmit)} onChange={handleChange}>
         <InputField
           ref={register({ required: 'Required' })}
           className="flex-1 mr-4"

--- a/src/popup/App/Options/RendezvousForm/RendezvousForm.js
+++ b/src/popup/App/Options/RendezvousForm/RendezvousForm.js
@@ -9,15 +9,15 @@ function RendezvousForm(props) {
   const { handleSubmit, register, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  async function onSubmit(data) {
+  function onSubmit(data) {
     const aggregated = options.unsavedForms.payment || options.unsavedForms.price || options.unsavedForms.lotus;
 
-    await setOptions({
+    setOptions({
       ...data, unsavedForms: {
         ...options.unsavedForms,
         rendezvous: false,
-        unsaved: aggregated
-      }
+      },
+      unsaved: aggregated
     });
   }
 

--- a/src/popup/App/Options/RendezvousForm/RendezvousForm.js
+++ b/src/popup/App/Options/RendezvousForm/RendezvousForm.js
@@ -9,10 +9,10 @@ function RendezvousForm(props) {
   const { handleSubmit, register, errors } = useForm();
   const [options, setOptions] = useOptions();
 
-  function onSubmit(data) {
+  async function onSubmit(data) {
     const aggregated = options.unsavedForms.payment || options.unsavedForms.price || options.unsavedForms.lotus;
 
-    setOptions({
+    await setOptions({
       ...data, unsavedForms: {
         ...options.unsavedForms,
         rendezvous: false,

--- a/src/popup/components/Tabs/Tabs.js
+++ b/src/popup/components/Tabs/Tabs.js
@@ -7,14 +7,21 @@ function Tabs({ className, tabs, children, ...rest }) {
   const [isOpen, setIsOpen] = useState(false);
   const [currentTab, setCurrentTab] = useState(tabs[0]);
   const Component = currentTab.component;
-  const [options] = useOptions();
+  const [options, setOptions] = useOptions();
 
   function toggleIsOpen() {
     setIsOpen(!isOpen);
   }
 
   function checkUnsaved(tab) {
-    options.unsaved ? setIsOpen(true) : setCurrentTab(tab);
+    const aggregated = options.unsavedForms.rendezvous || options.unsavedForms.price || options.unsavedForms.lotus || options.unsavedForms.payment;
+
+    if (aggregated && tab.label !== 'Options') {
+      setIsOpen(true);
+      setOptions({unsaved: true});
+    } else {
+      setCurrentTab(tab);
+    }
   }
 
   return (

--- a/src/popup/components/Tabs/Tabs.js
+++ b/src/popup/components/Tabs/Tabs.js
@@ -53,7 +53,7 @@ function Tabs({ className, tabs, children, ...rest }) {
                 className="relative flex-1 m-8 min-w-0 rounded bg-white p-4 shadow-xl"
                 onClick={event => event.stopPropagation()}
             >
-              <Label>You have unsaved options! Please check them and hit save button!</Label>
+              <Label>You have unsaved values in the Options fields. Please press Save to set those values.</Label>
             </div>
           </div>
       )}

--- a/src/popup/components/Tabs/Tabs.js
+++ b/src/popup/components/Tabs/Tabs.js
@@ -1,9 +1,21 @@
 import React, { useState } from 'react';
 import classNames from 'classnames';
+import useOptions from "src/popup/hooks/useOptions";
+import Label from "src/popup/components/Label";
 
 function Tabs({ className, tabs, children, ...rest }) {
+  const [isOpen, setIsOpen] = useState(false);
   const [currentTab, setCurrentTab] = useState(tabs[0]);
   const Component = currentTab.component;
+  const [options] = useOptions();
+
+  function toggleIsOpen() {
+    setIsOpen(!isOpen);
+  }
+
+  function checkUnsaved(tab) {
+    options.unsaved ? setIsOpen(true) : setCurrentTab(tab);
+  }
 
   return (
     <div
@@ -24,7 +36,7 @@ function Tabs({ className, tabs, children, ...rest }) {
                     ? 'border-brand text-brand'
                     : 'border-transparent text-darkgray hover:text-black',
                 )}
-                onClick={() => setCurrentTab(tab)}
+                onClick={() => checkUnsaved(tab)}
                 type="button"
               >
                 {tab.label}
@@ -34,6 +46,17 @@ function Tabs({ className, tabs, children, ...rest }) {
         })}
       </ul>
       <Component />
+      {isOpen && (
+          <div className="fixed inset-0 flex items-center justify-center z-10" onClick={toggleIsOpen}>
+            <div className="absolute inset-0 bg-black opacity-50" />
+            <div
+                className="relative flex-1 m-8 min-w-0 rounded bg-white p-4 shadow-xl"
+                onClick={event => event.stopPropagation()}
+            >
+              <Label>You have unsaved options! Please check them and hit save button!</Label>
+            </div>
+          </div>
+      )}
     </div>
   );
 }

--- a/src/popup/styles/tailwind.css
+++ b/src/popup/styles/tailwind.css
@@ -23,3 +23,7 @@ svg {
 .min-h-10 {
   min-height: 2.5rem;
 }
+
+.border-2-blue {
+  border: 2px solid blue;
+}

--- a/src/shared/getOptions.js
+++ b/src/shared/getOptions.js
@@ -24,7 +24,8 @@ const defaultValues = {
       '////////////////////////////////////////////////////////////////////////////////////\n' +
       '// Here\'s how to change the price of a CID your node is offering\n' +
       'let price = "5000"; // total price for the CID (Price/byte AttoFIL)\n' +
-      'this.updatePrice(cid, price);'
+      'this.updatePrice(cid, price);',
+  unsaved: false
 };
 
 export const optionsKeys = Object.keys(defaultValues);

--- a/src/shared/getOptions.js
+++ b/src/shared/getOptions.js
@@ -25,7 +25,8 @@ const defaultValues = {
       '// Here\'s how to change the price of a CID your node is offering\n' +
       'let price = "5000"; // total price for the CID (Price/byte AttoFIL)\n' +
       'this.updatePrice(cid, price);',
-  unsaved: false
+  unsaved: false,
+  unsavedForms: {lotus: false, payment: false, price: false, rendezvous: false}
 };
 
 export const optionsKeys = Object.keys(defaultValues);


### PR DESCRIPTION
If the user tries to move away from the Options tab without pressing Save, a message (like a modal dialog) should pop up warning that "You have unsaved values in the Options fields. Please press Save to set those values." The forms that are filled in but not yet saved should be highlighted, and pressing Save should remove the highlight.