### PR TITLE
Add toast messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.ts]
+quote_type = single
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dropzone": "^11.0.1",
     "react-hook-form": "^6.0.0",
     "react-scripts": "3.4.1",
+    "react-use-localstorage": "^3.5.3",
     "socket.io-client": "^2.3.1",
     "tailwindcss": "^1.4.6",
     "wasm-loader": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "webpack-cli": "^3.3.12"
   },
   "scripts": {
-    "build:popup:css": "NODE_ENV=production postcss src/popup/styles/tailwind.css -o src/popup/styles/tailwind.generated.css",
-    "build:popup:js": "INLINE_RUNTIME_CHUNK=false react-app-rewired build",
+    "build:popup:css": "cross-env NODE_ENV=production postcss src/popup/styles/tailwind.css -o src/popup/styles/tailwind.generated.css",
+    "build:popup:js": "cross-env INLINE_RUNTIME_CHUNK=false react-app-rewired build",
     "build:popup": "yarn build:popup:css && yarn build:popup:js",
-    "build:background": "NODE_ENV=development webpack",
+    "build:background": "cross-env NODE_ENV=development webpack",
     "build": "yarn build:popup && yarn build:background",
-    "build:debug": "DEBUG=true yarn build",
+    "build:debug": "cross-env DEBUG=true yarn build",
     "watch": "npm-watch"
   },
   "watch": {
@@ -78,5 +78,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.2",
+    "npm-watch": "^0.7.0"
   }
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -83,11 +83,16 @@ async function startNode() {
     node = await Node.create(options);
   } catch (error) {
     if (error === 'Error: `Invalid Key Length`') {
-      ports.postLog(`ERROR: start node failed: ${error}`);
+      const emsg = `ERROR: start node failed: ${error}`;
+      ports.postLog(emsg);
       ports.postLog('INFO: fix your lotus config on the Options page');
+      ports.alertError(emsg);
     } else {
       console.error(error);
-      ports.postLog(`ERROR: start node failed: ${error.message}`);
+
+      const emsg = `ERROR: start node failed: ${error.message}`
+      ports.postLog(emsg);
+      ports.alertError(emsg);
     }
   }
 }

--- a/src/background/ports.js
+++ b/src/background/ports.js
@@ -77,13 +77,18 @@ const ports = {
       logs.push(message);
       ports.postMessage(channels.logs, logs);
     }
+  },
 
-    const isError = message.startsWith('ERROR');
-    const isWarning = message.startsWith('WARN');
+  alertError(message) {
+    toast.create({ message, type: 'error' });
+  },
 
-    if (isError || isWarning) {
-      toast.create({ message, type: isError ? 'error' : 'warning' });
-    }
+  alertWarning(message) {
+    toast.create({ message, type: 'warning' });
+  },
+
+  alertSuccess(message) {
+    toast.create({ message, type: 'success' });
   },
 
   clearLogs() {

--- a/src/background/ports.js
+++ b/src/background/ports.js
@@ -1,6 +1,7 @@
 /* global chrome */
-
 import channels from 'src/shared/channels';
+
+import * as toast from '../shared/toast.js';
 
 const debug = true;
 const portsByChannel = {};
@@ -10,7 +11,7 @@ const logs = [];
 
 const ports = {
   startListening() {
-    chrome.runtime.onConnect.addListener(port => {
+    chrome.runtime.onConnect.addListener((port) => {
       const channel = port.name;
 
       if (!portsByChannel[channel]) {
@@ -23,7 +24,7 @@ const ports = {
         port.postMessage(lastMessages[channel]);
       }
 
-      port.onDisconnect.addListener(port => {
+      port.onDisconnect.addListener((port) => {
         const channel = port.name;
 
         portsByChannel[channel].delete(port);
@@ -35,7 +36,7 @@ const ports = {
     lastMessages[channel] = message;
 
     if (portsByChannel[channel]) {
-      portsByChannel[channel].forEach(port => port.postMessage(message));
+      portsByChannel[channel].forEach((port) => port.postMessage(message));
     }
   },
 
@@ -75,6 +76,13 @@ const ports = {
     if (!message.startsWith('DEBUG') || debug) {
       logs.push(message);
       ports.postMessage(channels.logs, logs);
+    }
+
+    const isError = message.startsWith('ERROR');
+    const isWarning = message.startsWith('WARN');
+
+    if (isError || isWarning) {
+      toast.create({ message, type: isError ? 'error' : 'warning' });
     }
   },
 

--- a/src/popup/App/App.js
+++ b/src/popup/App/App.js
@@ -1,18 +1,19 @@
 /* global chrome */
-
 import React from 'react';
-import useOptions from 'src/popup/hooks/useOptions';
 import Tabs from 'src/popup/components/Tabs';
-import Home from './Home';
-import Options from './Options';
-import Logs from './Logs';
-import Editor from './Editor';
-import Upload from './Upload';
-import ConnectionIndicator from './ConnectionIndicator';
-import PeersIndicator from './PeersIndicator';
+import useOptions from 'src/popup/hooks/useOptions';
+import { ENVIRONMENT_TYPE_FULLSCREEN } from 'src/shared/enums';
+import { getEnvironmentType } from 'src/shared/getEnvironmentType';
 import messageTypes from 'src/shared/messageTypes';
-import {getEnvironmentType} from 'src/shared/getEnvironmentType';
-import {ENVIRONMENT_TYPE_FULLSCREEN} from 'src/shared/enums'
+
+import ConnectionIndicator from './ConnectionIndicator';
+import Editor from './Editor';
+import Home from './Home';
+import Logs from './Logs';
+import Options from './Options';
+import PeersIndicator from './PeersIndicator';
+import Toast from './Toast';
+import Upload from './Upload';
 
 const tabs = [
   {
@@ -50,13 +51,16 @@ function App() {
   }
 
   return (
-    <Tabs className="text-xs text-black" tabs={tabs}>
-      <li className="flex-1 px-4">Filecoin Retrieval</li>
-      <li className="flex mr-8">
-        <ConnectionIndicator />
-        <PeersIndicator />
-      </li>
-    </Tabs>
+    <>
+      <Toast />
+      <Tabs className="text-xs text-black" tabs={tabs}>
+        <li className="flex-1 px-4">Filecoin Retrieval</li>
+        <li className="flex mr-8">
+          <ConnectionIndicator />
+          <PeersIndicator />
+        </li>
+      </Tabs>
+    </>
   );
 }
 

--- a/src/popup/App/Toast/Toast.css
+++ b/src/popup/App/Toast/Toast.css
@@ -1,0 +1,41 @@
+.toast {
+  position: fixed;
+  width: 100%;
+  z-index: 10;
+}
+
+.toast-item {
+  display: flex;
+
+  border-radius: 0.25rem;
+  border: 1px solid transparent;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  position: relative;
+}
+
+.toast-item div:first-child {
+  flex: 1;
+}
+
+.toast-item.error {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+
+.toast-item.warning {
+  color: #856404;
+  background-color: #fff3cd;
+  border-color: #ffeeba;
+}
+
+.toast-item.success {
+  color: #155724;
+  background-color: #d4edda;
+  border-color: #c3e6cb;
+}
+
+.dismiss {
+  cursor: pointer;
+}

--- a/src/popup/App/Toast/Toast.js
+++ b/src/popup/App/Toast/Toast.js
@@ -1,0 +1,36 @@
+import './Toast.css';
+
+import classNames from 'classnames';
+import React from 'react';
+import useLocalStorage from 'react-use-localstorage';
+
+import * as toast from '../../../shared/toast';
+
+function Toast({ className, ...rest }) {
+  const [messagesJson, setMessagesJson] = useLocalStorage('toast', '[]');
+
+  const messages = JSON.parse(messagesJson);
+
+  if (!messages || !messages.length) {
+    return null;
+  }
+
+  const dismiss = (id) => {
+    toast.dismiss(id, setMessagesJson)
+  }
+
+  return (
+    <div className={classNames(className, 'p-4 toast')} {...rest}>
+      {messages.map((msg) => (
+        <div key={msg.id} className={classNames(msg.type, 'toast-item')}>
+          <div>{msg.message}</div>
+          <button className="dismiss" onClick={() => dismiss(msg.id)}>
+            dismiss
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default Toast;

--- a/src/popup/App/Toast/index.js
+++ b/src/popup/App/Toast/index.js
@@ -1,0 +1,2 @@
+export * from './Toast';
+export { default } from './Toast';

--- a/src/shared/toast.js
+++ b/src/shared/toast.js
@@ -1,0 +1,41 @@
+/**
+ * Creates a toast message.
+ *
+ * @param  {object} Message
+ * @param  {string} Message.message Message to display
+ * @param  {'error'|'warning'|'success'} Message.type Type of the message
+ * @param  {Func} setMessagesJson React hook function if available
+ */
+export const create = ({ message, type }, setMessagesJson) => {
+  const toastMessages = JSON.parse(localStorage.getItem('toast') || '[]');
+
+  toastMessages.push({
+    id: Date.now(),
+    message,
+    type,
+  });
+
+  if (setMessagesJson) {
+    setMessagesJson(JSON.stringify(toastMessages));
+  } else {
+    localStorage.setItem('toast', JSON.stringify(toastMessages));
+  }
+};
+
+/**
+ * Dismiss a toast message.
+ *
+ * @param  {number} id ID of the toast message to dismiss
+ * @param  {Func} setMessagesJson React hook function if available
+ */
+export const dismiss = (id, setMessagesJson) => {
+  const toastMessages = JSON.parse(localStorage.getItem('toast') || '[]');
+
+  const excludeId = toastMessages.filter((m) => m.id !== id);
+
+  if (setMessagesJson) {
+    setMessagesJson(JSON.stringify(excludeId));
+  } else {
+    localStorage.setItem('toast', JSON.stringify(excludeId));
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -11706,6 +11706,11 @@ react-scripts@3.4.1:
   optionalDependencies:
     fsevents "2.1.2"
 
+react-use-localstorage@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/react-use-localstorage/-/react-use-localstorage-3.5.3.tgz#c4bcc097859a2d2879e969f0a57b16345905df82"
+  integrity sha512-1oNvJmo72G4v5P9ytJZZTb6ywD3UzWBiainTtfbNlb+U08hc+SOD5HqgiLTKUF0MxGcIR9JSnZGmBttNLXaQYA==
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"


### PR DESCRIPTION
Closes #64 

# Changes

- Added 3 functions to triggers a toast message in the ports file:
    - `alertError`: shows an error bar (red)
    - `alertWarning`: shows a warning bar (yellow)
    - `alertSuccess`: shows a success bar (green)
- Added a `localStorage` key `toast` that manages the state of the toast messages in the system
- Added the toast message on top of the application displaying over the other elements

# Preview

![toast-message](https://user-images.githubusercontent.com/706078/96461466-cb957d00-11fa-11eb-9bf6-2edc99765392.gif)
