### PR TITLE
Offers fixes

### DIFF
--- a/src/background/Node.js
+++ b/src/background/Node.js
@@ -205,6 +205,10 @@ class Node {
 
   async clearOffers() {
     const options = await getOptions();
+    
+    if (options.offerInfo.cid) {
+      this.queriedCids.delete(options.offerInfo.cid);
+    }
 
     await setOptions({
       ...options,
@@ -306,7 +310,6 @@ class Node {
 
     try {
       await this.client.retrieve(cid, params, multiaddr);  // TODO:  peer wallet!
-      this.queriedCids.delete(cid);
     } catch (error) {
       console.error(error);
       ports.postLog(`ERROR: Node.initiateRetrieval():  failed: ${error.message}`);


### PR DESCRIPTION
Closes #52 

- [x] The buy button should show a transfer of $CID1 starting, a progress bar and completion.
- [x] ~If there is an error, it should be shown in the main UI (not only in the log).~ #64 
- [x] User should still be able to click other buy buttons to initiate additional buys of $CID1
- [x] Only once the user queries for a different CID ($CID2), or all transfers for $CID1 have completed, should the box showing Offers for CID {$CID1} disappear.
- [x] Even if the box disappears, transfers should continue.