### PR TITLE
Add support to schedule operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "libp2p-webrtc-star": "^0.18.6",
     "libp2p-websockets": "^0.13.6",
     "lodash": "^4.17.15",
+    "luxon": "^1.25.0",
     "multihashing-async": "^1.0.0",
     "peer-id": "^0.13.13",
     "postcss-cli": "^7.1.1",
@@ -82,9 +83,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "cross-env": "^7.0.2",
-    "npm-watch": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.2",
-    "npm-watch": "^0.7.0"
+    "npm-watch": "^0.7.0",
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "build:popup:css": "cross-env NODE_ENV=production postcss src/popup/styles/tailwind.css -o src/popup/styles/tailwind.generated.css",
@@ -63,6 +64,7 @@
     "build:background": "cross-env NODE_ENV=development webpack",
     "build": "yarn build:popup && yarn build:background",
     "build:debug": "cross-env DEBUG=true yarn build",
+    "lint": "eslint ./src",
     "watch": "npm-watch"
   },
   "watch": {

--- a/src/background/Node.js
+++ b/src/background/Node.js
@@ -229,6 +229,7 @@ class Node {
       const { automationCode } = await getOptions();
 
       try {
+        // eslint-disable-next-line
         eval(automationCode);
       } catch (error) {
         ports.postLog(`ERROR: automation loop failed: ${error.message}`);
@@ -245,6 +246,7 @@ class Node {
       const { automationCode } = await getOptions();
       ports.postLog(`INFO: automation code saved`);
 
+      // eslint-disable-next-line
       eval(automationCode);
       this.lastIntervalId = this.runInLoop();
     } catch (error) {

--- a/src/background/Node.js
+++ b/src/background/Node.js
@@ -205,7 +205,7 @@ class Node {
 
   async clearOffers() {
     const options = await getOptions();
-    
+
     if (options.offerInfo.cid) {
       this.queriedCids.delete(options.offerInfo.cid);
     }
@@ -301,7 +301,7 @@ class Node {
       ports.postLog(`DEBUG:  Node._downloadFromPeer: exiting because Node.queriedCids does not contain '${cid}'`);
       return;
     }
-    
+
     ports.postLog(`DEBUG:  Node._downloadFromPeer:  offer=${JSON.stringify(offer)}`);
     ports.postLog(`DEBUG:  Node._downloadFromPeer:\n  CID: ${cid}\n  from: ${offer.address}\n  price: ${offer.price} attoFil`);
 

--- a/src/background/lotus-client/Lotus.js
+++ b/src/background/lotus-client/Lotus.js
@@ -1,10 +1,9 @@
-import dagCBOR from 'ipld-dag-cbor';
 import * as signer from '@zondax/filecoin-signing-tools';
-import onOptionsChanged from 'src/shared/onOptionsChanged';
+import dagCBOR from 'ipld-dag-cbor';
 import getOptions from 'src/shared/getOptions';
+import onOptionsChanged from 'src/shared/onOptionsChanged';
+
 import ports from '../ports';
-import methods from './methods';
-import codes from './codes';
 
 class Lotus {
   static async create() {
@@ -16,7 +15,6 @@ class Lotus {
   id = 0;
 
   paymentChannelsInfo = {};
-
 
   async initialize() {
     await this.updateOptions();
@@ -31,13 +29,8 @@ class Lotus {
     this.privateKey = signer.keyRecover(privateKey).private_hexstring;
   }
 
-  handleOptionsChange = async changes => {
-    if (
-      changes['lotusEndpoint'] ||
-      changes['lotusToken'] ||
-      changes['wallet'] ||
-      changes['privateKey']
-    ) {
+  handleOptionsChange = async (changes) => {
+    if (changes['lotusEndpoint'] || changes['lotusToken'] || changes['wallet'] || changes['privateKey']) {
       try {
         await this.updateOptions();
       } catch (error) {
@@ -102,7 +95,7 @@ class Lotus {
       } catch (error) {
         if (error.message === 'blockstore: block not found') {
           // try again in a second
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
         } else {
           throw error;
         }
@@ -113,41 +106,41 @@ class Lotus {
   async getOrCreatePaymentChannel(to, value) {
     ports.postLog(`DEBUG: creating Payment Channel [from:${this.wallet}, to:${to}, amount:${value}`);
 
-    return "address"
+    return 'address';
 
     // TODO: recycle existing channel
 
-    const messageLink = await this.post('Filecoin.MpoolPush', [
-      this.signMessage({
-        to,
-        from: this.wallet,
-        value: value.toString(),
-        method: methods.init.exec,
-        params: {
-          CodeCID: codes.paymentChannel,
-          ConstructorParams: {
-            From: this.wallet,
-            To: to,
-          },
-        },
-        gaslimit: 1000000,
-        gasprice: '1000',
-        nonce: await this.getNextNonce(),
-      }),
-    ]);
+    // const messageLink = await this.post('Filecoin.MpoolPush', [
+    //   this.signMessage({
+    //     to,
+    //     from: this.wallet,
+    //     value: value.toString(),
+    //     method: methods.init.exec,
+    //     params: {
+    //       CodeCID: codes.paymentChannel,
+    //       ConstructorParams: {
+    //         From: this.wallet,
+    //         To: to,
+    //       },
+    //     },
+    //     gaslimit: 1000000,
+    //     gasprice: '1000',
+    //     nonce: await this.getNextNonce(),
+    //   }),
+    // ]);
 
-    const receipt = await this.waitForMessage(messageLink);
-    console.log(receipt);
+    // const receipt = await this.waitForMessage(messageLink);
+    // console.log(receipt);
 
-    // TODO: get address from receipt
-    const paymentChannel = 'address';
+    // // TODO: get address from receipt
+    // const paymentChannel = 'address';
 
-    this.paymentChannelsInfo[paymentChannel] = {
-      nextLane: 0,
-      lanesNextNonce: {},
-    };
+    // this.paymentChannelsInfo[paymentChannel] = {
+    //   nextLane: 0,
+    //   lanesNextNonce: {},
+    // };
 
-    return paymentChannel;
+    // return paymentChannel;
   }
 
   async allocateLane(paymentChannel) {

--- a/src/background/lotus-client/Lotus.js
+++ b/src/background/lotus-client/Lotus.js
@@ -1,9 +1,13 @@
 import * as signer from '@zondax/filecoin-signing-tools';
-import dagCBOR from 'ipld-dag-cbor';
 import getOptions from 'src/shared/getOptions';
 import onOptionsChanged from 'src/shared/onOptionsChanged';
 
 import ports from '../ports';
+
+// Required to workaround `Invalid asm.js: Unexpected token` error
+const importDagCBOR = () => {
+  return require('ipld-dag-cbor');
+}
 
 class Lotus {
   static async create() {
@@ -40,7 +44,9 @@ class Lotus {
     }
   };
 
-  cbor(object) {
+  async cbor(object) {
+    const dagCBOR = importDagCBOR();
+
     return dagCBOR.util.serialize(object).toString('hex');
   }
 

--- a/src/background/retrieval-market/Provider.js
+++ b/src/background/retrieval-market/Provider.js
@@ -1,12 +1,10 @@
 import pipe from 'it-pipe';
 import pushable from 'it-pushable';
-import { DateTime } from 'luxon';
 import ports from 'src/background/ports';
 import dealStatuses from 'src/shared/dealStatuses';
 import getOptions from 'src/shared/getOptions';
 import jsonStream from 'src/shared/jsonStream';
 import onOptionsChanged from 'src/shared/onOptionsChanged';
-import { operationsQueue } from 'src/shared/OperationsQueue';
 import protocols from 'src/shared/protocols';
 
 class Provider {

--- a/src/background/retrieval-market/Provider.js
+++ b/src/background/retrieval-market/Provider.js
@@ -6,9 +6,8 @@ import dealStatuses from 'src/shared/dealStatuses';
 import getOptions from 'src/shared/getOptions';
 import jsonStream from 'src/shared/jsonStream';
 import onOptionsChanged from 'src/shared/onOptionsChanged';
+import { operationsQueue } from 'src/shared/OperationsQueue';
 import protocols from 'src/shared/protocols';
-
-import { operationsQueue } from '../../shared/OperationsQueue';
 
 class Provider {
   static async create(...args) {
@@ -225,20 +224,6 @@ class Provider {
     ports.postLog(`DEBUG: closing deal ${dealId}`);
     const deal = this.ongoingDeals[dealId];
     deal.sink.end();
-
-    operationsQueue.queue({
-      label: 'label -> operation in 1 min',
-      f: 'testQueue',
-      metadata: deal,
-      invokeAt: DateTime.local().plus({ minutes: 1 }).toString(),
-    });
-
-    operationsQueue.queue({
-      label: 'label -> operation in 2 mins',
-      f: 'testQueue',
-      metadata: deal,
-      invokeAt: DateTime.local().plus({ minutes: 2 }).toString(),
-    });
 
     delete this.ongoingDeals[dealId];
     ports.postOutboundDeals(this.ongoingDeals);

--- a/src/popup/App/Home/Home.js
+++ b/src/popup/App/Home/Home.js
@@ -1,9 +1,11 @@
-import React from 'react';
 import classNames from 'classnames';
-import QueryForm from './QueryForm';
-import KnownCids from './KnownCids';
+import React from 'react';
+
 import Deals from './Deals';
+import KnownCids from './KnownCids';
 import Offers from './Offers';
+import OperationsList from './OperationsList';
+import QueryForm from './QueryForm';
 
 function Home({ className, ...rest }) {
   return (
@@ -12,6 +14,7 @@ function Home({ className, ...rest }) {
       <Offers className="mt-4" />
       <KnownCids className="mt-4" />
       <Deals className="mt-4" />
+      <OperationsList className="mt-4" />
     </div>
   );
 }

--- a/src/popup/App/Home/OperationsList/OperationsList.js
+++ b/src/popup/App/Home/OperationsList/OperationsList.js
@@ -1,0 +1,61 @@
+/* global chrome */
+import { DateTime } from 'luxon';
+import React, { useState, useEffect } from 'react';
+import Card from 'src/popup/components/Card';
+import Label from 'src/popup/components/Label';
+import Table from 'src/popup/components/Table';
+import TableCell from 'src/popup/components/TableCell';
+import TableRow from 'src/popup/components/TableRow';
+import { operationsQueue } from 'src/shared/OperationsQueue';
+
+const renderStatus = ({ status, invokeAt }) => {
+  if (!status || status === 'waiting') {
+    return DateTime.fromJSDate(invokeAt).diff(DateTime.local()).toFormat('hh:mm:ss');
+  }
+
+  return status;
+};
+
+const renderOpsTable = (ops) => {
+  if (!ops) {
+    return <>No operations</>;
+  }
+
+  return (
+    <Table>
+      <tbody>
+        {ops.map((op) => (
+          <TableRow key={op.id}>
+            <TableCell width="250px">{op.label}</TableCell>
+            <TableCell width="80px" title={op.invokeAt?.toISOString()}>{renderStatus(op)}</TableCell>
+            <TableCell>{op.output || '-'}</TableCell>
+          </TableRow>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+function OperationsList(props) {
+  // eslint-disable-next-line no-unused-vars
+  const [_time, setTime] = useState(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setTime(Date.now()), 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  const ops = operationsQueue.operations;
+
+  return (
+    <Card {...props}>
+      <Label className="p-4 pb-2">Operations</Label>
+
+      {renderOpsTable(ops)}
+    </Card>
+  );
+}
+
+export default OperationsList;

--- a/src/popup/App/Home/OperationsList/OperationsList.js
+++ b/src/popup/App/Home/OperationsList/OperationsList.js
@@ -1,6 +1,6 @@
 /* global chrome */
 import { DateTime } from 'luxon';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Card from 'src/popup/components/Card';
 import Label from 'src/popup/components/Label';
 import Table from 'src/popup/components/Table';
@@ -9,28 +9,63 @@ import TableRow from 'src/popup/components/TableRow';
 import { operationsQueue } from 'src/shared/OperationsQueue';
 
 const renderStatus = ({ status, invokeAt }) => {
-  if (!status || status === 'waiting') {
-    return DateTime.fromJSDate(invokeAt).diff(DateTime.local()).toFormat('hh:mm:ss');
+  if (!status || ['waiting', 'running'].includes(status)) {
+    const diff = DateTime.fromJSDate(invokeAt).diff(DateTime.local());
+
+    if (diff.as('milliseconds') > 0) {
+      return diff.toFormat('hh:mm:ss');
+    }
+
+    return `running for ${-diff.as('seconds') | 0}s`;
   }
 
   return status;
 };
 
+const dismiss = (operation) => {
+  operationsQueue.remove(operation);
+};
+
+/**
+ * @param {Array.<any>} ops Operations
+ */
 const renderOpsTable = (ops) => {
-  if (!ops) {
-    return <>No operations</>;
+  if (!ops || !ops.length) {
+    return <div className="p-4 py-2">No operations</div>;
   }
 
   return (
     <Table>
       <tbody>
-        {ops.map((op) => (
-          <TableRow key={op.id}>
-            <TableCell width="250px">{op.label}</TableCell>
-            <TableCell width="80px" title={op.invokeAt?.toISOString()}>{renderStatus(op)}</TableCell>
-            <TableCell>{op.output || '-'}</TableCell>
-          </TableRow>
-        ))}
+        {ops
+          .sort((a, b) => {
+            const diff = a.invokeAt - b.invokeAt;
+            if (isNaN(diff)) {
+              return -2;
+            }
+
+            if (!diff) {
+              return 0;
+            }
+
+            return diff > 0 ? 1 : -1;
+          })
+          .map((op) => (
+            <TableRow key={op.id}>
+              <TableCell width="250px">{op.label}</TableCell>
+              <TableCell width="80px" title={op.invokeAt?.toISOString()}>
+                {renderStatus(op)}
+              </TableCell>
+              <TableCell>{op.output || '-'}</TableCell>
+              {['done', 'failed'].includes(op.status) ? (
+                <TableCell>
+                  <button onClick={() => dismiss(op)}>dismiss</button>
+                </TableCell>
+              ) : (
+                <>&nbsp;</>
+              )}
+            </TableRow>
+          ))}
       </tbody>
     </Table>
   );

--- a/src/popup/App/Home/OperationsList/OperationsList.js
+++ b/src/popup/App/Home/OperationsList/OperationsList.js
@@ -1,4 +1,3 @@
-/* global chrome */
 import { DateTime } from 'luxon';
 import React, { useEffect, useState } from 'react';
 import Card from 'src/popup/components/Card';

--- a/src/popup/App/Home/OperationsList/index.js
+++ b/src/popup/App/Home/OperationsList/index.js
@@ -1,0 +1,2 @@
+export * from './OperationsList';
+export { default } from './OperationsList';

--- a/src/popup/App/Home/QueryForm/QueryForm.js
+++ b/src/popup/App/Home/QueryForm/QueryForm.js
@@ -1,14 +1,13 @@
 /* global chrome */
-
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import Card from 'src/popup/components/Card';
-import Form from 'src/popup/components/Form';
-import Label from 'src/popup/components/Label';
-import Input from 'src/popup/components/Input';
-import Checkbox from 'src/popup/components/Checkbox';
 import Button from 'src/popup/components/Button';
+import Card from 'src/popup/components/Card';
+import Checkbox from 'src/popup/components/Checkbox';
 import Error from 'src/popup/components/Error';
+import Form from 'src/popup/components/Form';
+import Input from 'src/popup/components/Input';
+import Label from 'src/popup/components/Label';
 import messageTypes from 'src/shared/messageTypes';
 
 function QueryForm(props) {
@@ -17,15 +16,15 @@ function QueryForm(props) {
 
   function onSubmit({ cid, minerID }) {
     const msg = {
-      cid: cid,
-      minerID: minerID
-    }
-    chrome.runtime.sendMessage({ messageType: messageTypes.query, msg});
+      cid,
+      minerID,
+    };
+    chrome.runtime.sendMessage({ messageType: messageTypes.query, msg });
   }
 
   function onCheck() {
     if (checked) {
-      document.getElementById("minerID").value = '';
+      document.getElementById('minerID').value = '';
     }
 
     return setChecked(!checked);
@@ -34,7 +33,6 @@ function QueryForm(props) {
   return (
     <Card {...props}>
       <Form className="flex-col" onSubmit={handleSubmit(onSubmit)}>
-        
         <Label className="mb-2" for="cid">
           Query CID *
         </Label>
@@ -47,18 +45,24 @@ function QueryForm(props) {
 
         <div className="flex flex-row mt-2">
           <div className=" flex flex-row mr-2 mt-6">
-            <Checkbox className="mb-2" name="minerCheckbox" id="minerCheckbox" onClick={onCheck}/>
+            <Checkbox className="mb-2" name="minerCheckbox" id="minerCheckbox" onClick={onCheck} />
             <Label className="mt-1" for="minerCheckbox">
               Query primary market also?
             </Label>
           </div>
           <div className="flex-1">
-            <Label className={checked ? "mt-2 mb-2" : "mt-2 mb-2 opacity-50"} for="minerID">
+            <Label className={checked ? 'mt-2 mb-2' : 'mt-2 mb-2 opacity-50'} for="minerID">
               Miner ID
             </Label>
             <div className="flex">
-              <Input ref={register(checked ? {required: 'Required'} : {required: false})} id="minerID" name="minerID" className="flex-1 mr-4" disabled={!checked}/>
-              <div style={{width: '85px', height: '40px'}} />
+              <Input
+                ref={register(checked ? { required: 'Required' } : { required: false })}
+                id="minerID"
+                name="minerID"
+                className="flex-1 mr-4"
+                disabled={!checked}
+              />
+              <div style={{ width: '85px', height: '40px' }} />
             </div>
             {checked && <Error className="mt-2" error={errors.minerID} />}
           </div>

--- a/src/shared/Operations.js
+++ b/src/shared/Operations.js
@@ -1,0 +1,16 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Functions to be executed in a certain scheduled time.
+ */
+export class Operations {
+  async testQueue(lotus, metadata) {
+    console.log('lotus', lotus);
+    console.log('metadata', metadata);
+    console.log('luxon', DateTime);
+
+    return 'yo this works';
+  }
+}
+
+export const operations = new Operations();

--- a/src/shared/OperationsQueue.js
+++ b/src/shared/OperationsQueue.js
@@ -1,0 +1,169 @@
+/* eslint-disable no-unused-vars */
+import { DateTime } from 'luxon';
+import Lotus from 'src/background/lotus-client/Lotus';
+import ports from 'src/background/ports';
+
+import { errorToJSON } from './errorToJson';
+import { Operations, operations } from './Operations';
+
+/* eslint-enable no-unused-vars */
+
+/**
+ * @typedef {Object} Operation
+ * @property {string} id ID for tracking purposes
+ * @property {string} label Name of the operation
+ * @property {keyof Operations} f The function to run
+ * @property {{[key: string]: any}} metadata Metadata such as deal info
+ * @property {Date} invokeAt The time to invoke the function
+ * @property {'waiting' | 'running' | 'done'} status The status of the operation
+ * @property {number} attempts Number of attempts so far
+ * @property {string} output Function output
+ */
+
+class OperationsQueue {
+  /**
+   * @type Lotus
+   */
+  lotus;
+
+  constructor() {
+    this.initializeActionsQueue();
+  }
+
+  /**
+   * @readonly
+   */
+  get localStorageKey() {
+    return 'OperationsQueue';
+  }
+
+  /**
+   * Interval to watch for new operations in the queue.
+   *
+   * @readonly
+   */
+  get listenInterval() {
+    return 1000; // 1 sec
+  }
+
+  /**
+   * @returns {Array.<Operation>} Operations array
+   */
+  get operations() {
+    const ops = localStorage[this.localStorageKey] || '[]';
+
+    return JSON.parse(ops).map((op) => ({
+      ...op,
+      invokeAt: op.invokeAt ? new Date(op.invokeAt) : undefined,
+    }));
+  }
+
+  /**
+   * @param {Array.<Operation>} value Operations
+   */
+  set operations(value) {
+    localStorage[this.localStorageKey] = JSON.stringify(value);
+  }
+
+  /**
+   * @param {Operation} op Operation
+   */
+  queue(op) {
+    if (!op.f || !op.metadata) {
+      throw new Error('OperationsQueue: Function and metadata are required');
+    }
+
+    const ops = this.operations;
+
+    ops.push({
+      ...op,
+      id: Date.now() + Math.random().toString(36).substr(2, 9),
+    });
+
+    this.operations = ops;
+  }
+
+  /**
+   * @returns {Operation} Next operation in queue
+   */
+  dequeue() {
+    const ops = this.operations;
+
+    const next = ops.shift();
+
+    this.operations = ops;
+
+    return next;
+  }
+
+  /**
+   * Finds and updates an operation stored.
+   *
+   * @param {Operation} op Operation
+   * @param {Partial.<Operation>} props Operation props
+   */
+  updateOperation(op, props) {
+    const ops = this.operations;
+
+    const newOps = ops.map((storedOp) => {
+      if (storedOp.id === op.id) {
+        return {
+          ...storedOp,
+          ...props,
+        };
+      }
+
+      return storedOp;
+    });
+
+    this.operations = newOps;
+  }
+
+  async initializeActionsQueue() {
+    ports.postLog('DEBUG: OperationsQueue.initializeActionsQueue()');
+    this.lotus = await Lotus.create();
+
+    while (true) {
+      for (const op of this.operations) {
+        if (op.invokeAt && op.invokeAt <= new Date()) {
+          ports.postLog(`DEBUG: OperationsQueue.runOperation(): ${op.label}`);
+          this.runOperation(op);
+        }
+      }
+
+      await new Promise((r) => setTimeout(r, this.listenInterval));
+    }
+  }
+
+  /**
+   * Run a scheduled operation without locking the app.
+   *
+   * @param {Operation} op Operation
+   */
+  async runOperation(op) {
+    ports.postLog('DEBUG: OperationsQueue.runOperation(op)');
+
+    try {
+      this.updateOperation(op, {
+        status: 'running',
+      });
+
+      const response = await operations[op.f](this.lotus, op.metadata);
+
+      this.updateOperation(op, {
+        status: 'done',
+        invokeAt: undefined,
+        output: response,
+      });
+    } catch (err) {
+      this.updateOperation(op, {
+        status: 'waiting',
+        attempts: (op.attempts || 0) + 1,
+        invokeAt: DateTime.local().plus({ minutes: 10 }), // TODO: <<-- retry in,
+        output: `Error: ${errorToJSON(err)}`,
+      });
+    }
+  }
+}
+
+export const operationsQueue = new OperationsQueue();

--- a/src/shared/errorToJson.js
+++ b/src/shared/errorToJson.js
@@ -1,0 +1,16 @@
+export const errorToJSON = (err) => {
+  if (typeof err === 'string') {
+    return {
+      stack: new Error().stack,
+      message: err,
+    };
+  }
+
+  const alt = {};
+
+  Object.getOwnPropertyNames(err).forEach((key) => {
+    alt[key] = err[key];
+  }, err);
+
+  return alt;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13505,6 +13505,11 @@ typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
 typical@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-6.0.1.tgz#89bd1a6aa5e5e96fa907fb6b7579223bff558a06"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8906,6 +8906,11 @@ ltgt@^2.1.2:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
   integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
 
+luxon@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.25.0.tgz#d86219e90bc0102c0eb299d65b2f5e95efe1fe72"
+  integrity sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==
+
 mafmt@^7.0.0, mafmt@^7.0.1, mafmt@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-7.1.0.tgz#4126f6d0eded070ace7dbbb6fb04977412d380b5"


### PR DESCRIPTION
Closes #69 

# Changes

- Added:
    - `shared/Operations`: class that contains all functions that can be scheduled. The function must receive the parameters: `lotus` (an instance of the lotus class), `metadata` (information saved when the operation was queued; e.g. deal)
    - `shared/OperationsQueue`: class that handles the queue and execution of the operations
    - `popup/

# How to use

### Adding operations to the queue:

1. Add a function you'd like to execute on `shared/Operations.js` file
1. Add the operation to the queue using:
```ts
// package to handle dates
import { DateTime } from 'luxon';

// queue instance
import { operationsQueue } from 'src/shared/OperationsQueue';

operationsQueue.queue({
  label: 'the name of the operation here, anything',

  // name of the method implemented in shared/Operations
  // hint: VSCode should show you the available names through its built-in TypeScript support
  f: 'youFnNameAsInOperationsFile',

  // object with anything you want to store to pass to the operation later (e.g. `deal`)
  metadata: {},

  // time when to invoke the function
  invokeAt: DateTime.local().plus({ hours: 12 }).toString(),
});
```

# Preview
![operations](https://user-images.githubusercontent.com/706078/96900506-8e362700-1468-11eb-8ba1-e83640fcd2de.gif)
